### PR TITLE
support http range and digest as taskID

### DIFF
--- a/apis/swagger.yml
+++ b/apis/swagger.yml
@@ -793,6 +793,18 @@ definitions:
           this field to supernode and supernode can do some checking and filtering via
           black/white list mechanism to guarantee security, or some other purposes like debugging.
         minLength: 1
+      taskId:
+        type: "string"
+        description: |
+          Dfdaemon or dfget could specfic the taskID which will represents the key of this resource
+          in supernode.
+      fileLength:
+        type: "integer"
+        description: |
+          This attribute represents the length of resource, dfdaemon or dfget catches and calculates
+          this parameter from the headers of request URL. If fileLength is vaild, the supernode need
+          not get the length of resource by accessing the rawURL.
+        format: "int64"
 
   PeerCreateRequest:
     type: "object"
@@ -945,6 +957,18 @@ definitions:
           downloads, if there is already a task a.b.com/fileA.
         items:
           type: "string"
+      taskId:
+        type: "string"
+        description: |
+          This attribute represents the digest of resource, dfdaemon or dfget catches this parameter
+          from the headers of request URL. The digest will be considered as the taskID if not null.
+      fileLength:
+        type: "integer"
+        description: |
+          This attribute represents the length of resource, dfdaemon or dfget catches and calculates
+          this parameter from the headers of request URL. If fileLength is vaild, the supernode need
+          not get the length of resource by accessing the rawURL.
+        format: "int64"
       peerID:
         type: "string"
         description: |

--- a/apis/types/task_create_request.go
+++ b/apis/types/task_create_request.go
@@ -37,6 +37,12 @@ type TaskCreateRequest struct {
 	//
 	Dfdaemon bool `json:"dfdaemon,omitempty"`
 
+	// This attribute represents the length of resource, dfdaemon or dfget catches and calculates
+	// this parameter from the headers of request URL. If fileLength is vaild, the supernode need
+	// not get the length of resource by accessing the rawURL.
+	//
+	FileLength int64 `json:"fileLength,omitempty"`
+
 	// filter is used to filter request queries in URL.
 	// For example, when a user wants to start to download a task which has a remote URL of
 	// a.b.com/fileA?user=xxx&auth=yyy, user can add a filter parameter ["user", "auth"]
@@ -85,6 +91,11 @@ type TaskCreateRequest struct {
 
 	// IP address of supernode which the peer connects to
 	SupernodeIP string `json:"supernodeIP,omitempty"`
+
+	// This attribute represents the digest of resource, dfdaemon or dfget catches this parameter
+	// from the headers of request URL. The digest will be considered as the taskID if not null.
+	//
+	TaskID string `json:"taskId,omitempty"`
 
 	// taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.

--- a/apis/types/task_register_request.go
+++ b/apis/types/task_register_request.go
@@ -41,6 +41,12 @@ type TaskRegisterRequest struct {
 	//
 	Dfdaemon bool `json:"dfdaemon,omitempty"`
 
+	// This attribute represents the length of resource, dfdaemon or dfget catches and calculates
+	// this parameter from the headers of request URL. If fileLength is vaild, the supernode need
+	// not get the length of resource by accessing the rawURL.
+	//
+	FileLength int64 `json:"fileLength,omitempty"`
+
 	// extra HTTP headers sent to the rawURL.
 	// This field is carried with the request to supernode.
 	// Supernode will extract these HTTP headers, and set them in HTTP downloading requests
@@ -96,6 +102,11 @@ type TaskRegisterRequest struct {
 
 	// The address of supernode that the client can connect to
 	SuperNodeIP string `json:"superNodeIp,omitempty"`
+
+	// Dfdaemon or dfget could specfic the taskID which will represents the key of this resource
+	// in supernode.
+	//
+	TaskID string `json:"taskId,omitempty"`
 
 	// taskURL is generated from rawURL. rawURL may contains some queries or parameter, dfget will filter some queries via
 	// --filter parameter of dfget. The usage of it is that different rawURL may generate the same taskID.

--- a/dfdaemon/transport/transport.go
+++ b/dfdaemon/transport/transport.go
@@ -17,6 +17,7 @@
 package transport
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"io"
@@ -125,6 +126,14 @@ func WithCondition(c func(r *http.Request) bool) Option {
 // RoundTrip only process first redirect at present
 // fix resource release
 func (roundTripper *DFRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("x-nydus-proxy-healthcheck") != "" {
+		return &http.Response{
+			StatusCode: 200,
+			// add a body with no data
+			Body: ioutil.NopCloser(bytes.NewReader([]byte{})),
+		}, nil
+	}
+
 	if roundTripper.ShouldUseDfget(req) {
 		// delete the Accept-Encoding header to avoid returning the same cached
 		// result for different requests

--- a/dfget/config/config.go
+++ b/dfget/config/config.go
@@ -360,7 +360,7 @@ type RuntimeVariable struct {
 	// PeerPort is the TCP port on which the file upload service listens as a peer node.
 	PeerPort int
 
-	// FileLength the length of the file to download.
+	// FileLength the length of the file to download. It may be set if request url with range header
 	FileLength int64
 
 	// DataExpireTime specifies the caching duration for which
@@ -372,6 +372,9 @@ type RuntimeVariable struct {
 	// uploader keeps no accessing by any uploading requests.
 	// After this period, the uploader will automatically exit.
 	ServerAliveTime time.Duration
+
+	// the digest of resource, it could be got from url headers
+	Digest string
 }
 
 func (rv *RuntimeVariable) String() string {

--- a/dfget/config/constants.go
+++ b/dfget/config/constants.go
@@ -74,6 +74,8 @@ const (
 	StrTotalLimit   = "totalLimit"
 
 	StrBytes = "bytes"
+
+	StrDigest = "X-dragonfly-digest"
 )
 
 /* piece meta */

--- a/dfget/core/regist/register.go
+++ b/dfget/core/regist/register.go
@@ -160,6 +160,8 @@ func (s *supernodeRegister) constructRegisterRequest(port int) *types.RegisterRe
 		Headers:    cfg.Header,
 		Dfdaemon:   cfg.DFDaemon,
 		Insecure:   cfg.Insecure,
+		TaskId:     cfg.RV.Digest,
+		FileLength: cfg.RV.FileLength,
 	}
 	if cfg.Md5 != "" {
 		req.Md5 = cfg.Md5

--- a/dfget/types/register_request.go
+++ b/dfget/types/register_request.go
@@ -28,17 +28,19 @@ type RegisterRequest struct {
 	TaskURL     string   `json:"taskUrl"`
 	Cid         string   `json:"cid"`
 	IP          string   `json:"ip"`
-	HostName    string   `json:"hostName"`
-	Port        int      `json:"port"`
-	Path        string   `json:"path"`
-	Version     string   `json:"version,omitempty"`
-	Md5         string   `json:"md5,omitempty"`
-	Identifier  string   `json:"identifier,omitempty"`
-	CallSystem  string   `json:"callSystem,omitempty"`
-	Headers     []string `json:"headers,omitempty"`
-	Dfdaemon    bool     `json:"dfdaemon,omitempty"`
-	Insecure    bool     `json:"insecure,omitempty"`
-	RootCAs     [][]byte `json:"rootCAs,omitempty"`
+	HostName   string   `json:"hostName"`
+	Port       int      `json:"port"`
+	Path       string   `json:"path"`
+	Version    string   `json:"version,omitempty"`
+	Md5        string   `json:"md5,omitempty"`
+	Identifier string   `json:"identifier,omitempty"`
+	CallSystem string   `json:"callSystem,omitempty"`
+	Headers    []string `json:"headers,omitempty"`
+	Dfdaemon   bool     `json:"dfdaemon,omitempty"`
+	Insecure   bool     `json:"insecure,omitempty"`
+	RootCAs    [][]byte `json:"rootCAs,omitempty"`
+	TaskId     string   `json:"taskId,omitempty"`
+	FileLength int64    `json:"fileLength,omitempty"`
 }
 
 func (r *RegisterRequest) String() string {

--- a/supernode/server/0.3_bridge.go
+++ b/supernode/server/0.3_bridge.go
@@ -120,6 +120,8 @@ func (s *Server) registry(ctx context.Context, rw http.ResponseWriter, req *http
 		RawURL:      request.RawURL,
 		TaskURL:     request.TaskURL,
 		SupernodeIP: request.SuperNodeIP,
+		TaskID:      request.TaskID,
+		FileLength:  request.FileLength,
 	}
 	s.originClient.RegisterTLSConfig(taskCreateRequest.RawURL, request.Insecure, request.RootCAs)
 	resp, err := s.TaskMgr.Register(ctx, taskCreateRequest)


### PR DESCRIPTION
Signed-off-by: allen.wq <allen.wq@alipay.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
支持以文件块粒度的task，根据request header的digest 和 range字段，设置对应的taskID和fileLength。

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


